### PR TITLE
Match html tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Cargo.lock
+target
+*.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "leptos-locatorjs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
 lazy_static = "1.4.0"
-proc-macro2 = { version = "1.0.85", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.85", features = [] }
 quote = "1.0.36"
 regex = "1.10.4"
-syn = {version = "2.0.66", features = ["full"]}
+syn = { version = "2.0.66", features = ["full"] }
 [lib]
 proc-macro = true
 path = "lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "leptos-locatorjs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-proc-macro2 = "1.0.85"
+lazy_static = "1.4.0"
+proc-macro2 = { version = "1.0.85", features = ["span-locations"] }
 quote = "1.0.36"
+regex = "1.10.4"
 syn = {version = "2.0.66", features = ["full"]}
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -2,14 +2,38 @@
 
 EARLY DEVELOPMENT STAGE. DO NOT EXPECT THIS TO WORK.
 
+This macro adds the data-locatorjs-id attribute to all div, h1, h2, etc. elements in the Rust source code. The attribute is used by the LocatorJS library to uniquely identify HTML elements in automated tests.
+
 Example:
-```
+```rust
 #[component]
 #[leptos_locatorjs::add_locatorjs_id]
 pub fn Example() -> impl IntoView {
+    let (count, _) = create_signal(2);
+    let ressource = create_resource(|| (), |_| async move { pray_me().await });
+
+    let hello_word = move || {
+        let my_count = count.get();
+        match my_count {
+            2 => view! {<div>"Hello, world!"</div>},
+            _ => view! {<div>"Burn, world!"</div>},
+        }
+    };
+
+    let god____where_r_u = move || {
+        let _son_______i_am_everywhere = ressource.get();
+        "Je suis là, mon fils"
+    };
+
     view! {
         <div>
-            <h1>Hello, world!</h1>
+            <h1>{hello_word}</h1>
+            <Suspense fallback=|| view!{ <div>"Loading..."</div> }>
+                <ul>
+                    <li>"I like banana."</li>
+                    <li>{god____where_r_u}</li>
+                </ul>
+            </Suspense>
         </div>
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ Example:
 #[leptos_locatorjs::add_locatorjs_id]
 pub fn Example() -> impl IntoView {
     let (count, _) = create_signal(2);
+     // pause 5 seconds
     let ressource = create_resource(|| (), |_| async move { pray_me().await });
 
     let hello_word = move || {
         let my_count = count.get();
         match my_count {
-            2 => view! {<div>"Hello, world!"</div>},
-            _ => view! {<div>"Burn, world!"</div>},
+            2 => view! {<h2>"Hello, world!"</h2>},
+            _ => view! {<h2>"Burn, world!"</h2>},
         }
     };
 
@@ -27,7 +28,7 @@ pub fn Example() -> impl IntoView {
 
     view! {
         <div>
-            <h1>{hello_word}</h1>
+            <div>{hello_word}</div>
             <Suspense fallback=|| view!{ <div>"Loading..."</div> }>
                 <ul>
                     <li>"I like banana."</li>

--- a/lib.rs
+++ b/lib.rs
@@ -1,28 +1,61 @@
-extern crate proc_macro;
-extern crate quote;
-extern crate syn;
-
-use std::str::FromStr;
-
 use lazy_static::lazy_static;
-use regex::{Captures, Regex};
-
-use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Group, TokenStream, TokenTree};
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, ItemFn, Stmt::*};
+use regex::Regex;
+use syn::{parse_macro_input, ItemFn, Stmt};
 
 lazy_static! {
     // Match only few elements
-    static ref HTML_TAG_REGEX: Regex = Regex::new(r"<(div|h[1-6])\b[^>]*>").unwrap();
+    static ref HTML_REGEX: Regex = Regex::new(r"<(div|h[1-6])\b[^>]*>").unwrap();
+    static ref HTML_TAG_REGEX: Regex = Regex::new(r"div|h[1-6]").unwrap();
 }
 
+// https://discord.com/channels/1031524867910148188/1247813845414707280
 /// This macro adds the data-locatorjs-id attribute to all div, h1, h2, etc. elements in the source code.
 /// The attribute is used by the LocatorJS library to uniquely identify HTML elements in automated tests.
-/// The add_locatorjs_id function takes two arguments: _attr and item.
-/// The _attr argument is ignored, and the item argument is expected to be a function item.
+///
+/// ### Exemple
+///
+/// ```rust
+/// #[component]
+/// #[leptos_locatorjs::add_locatorjs_id]
+/// pub fn Example() -> impl IntoView {
+///     let (count, _) = create_signal(2);
+///     // pause 5 seconds
+///     let ressource = create_resource(|| (), |_| async move { pray_me().await });
+///
+///     let hello_word = move || {
+///         let my_count = count.get();
+///         match my_count {
+///             2 => view! {<h2>"Hello, world!"</h2>},
+///             _ => view! {<h2>"Burn, world!"</h2>},
+///         }
+///     };
+///
+///     let god____where_r_u = move || {
+///         let _son_______i_am_everywhere = ressource.get();
+///         "Je suis là, mon fils"
+///     };
+///
+///     view! {
+///         <div>
+///             <div>{hello_word}</div>
+///             <Suspense fallback=|| view!{ <div>"Loading..."</div> }>
+///                 <ul>
+///                     <li>"I like banana."</li>
+///                     <li>{god____where_r_u}</li>
+///                 </ul>
+///             </Suspense>
+///         </div>
+///     }
+/// }
+/// ```
+///
 #[proc_macro_attribute]
-pub fn add_locatorjs_id(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn add_locatorjs_id(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
     let input = parse_macro_input!(item as ItemFn);
     let ItemFn {
         attrs,
@@ -40,30 +73,30 @@ pub fn add_locatorjs_id(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #modified_block
     };
 
-    TokenStream::from(output)
+    proc_macro::TokenStream::from(output)
 }
 
 /// The add_locatorjs_id_to_block function is used to modify the block of the function.
 /// It iterates over each statement in the block and checks if it matches one of the specified patterns.
 /// If it does, the add_locatorjs_id_to_expr function is called to modify the expression and add the data-locatorjs-id attribute.
 fn add_locatorjs_id_to_block(block: Box<syn::Block>) -> Box<syn::Block> {
-    let mut new_block = TokenStream2::new();
+    let mut new_block = TokenStream::new();
 
     for stmt in block.stmts {
         match stmt.clone() {
-            Macro(stmt) => {
+            Stmt::Macro(stmt) => {
                 let modified_expr = add_locatorjs_id_to_expr(stmt);
                 new_block.extend(quote! { #modified_expr });
             }
-            Local(local) => {
+            Stmt::Local(local) => {
                 let modified_expr = add_locatorjs_id_to_expr(local);
                 new_block.extend(quote! { #modified_expr });
             }
-            Item(item) => {
+            Stmt::Item(item) => {
                 let modified_expr = add_locatorjs_id_to_expr(item);
                 new_block.extend(quote! { #modified_expr });
             }
-            Expr(expr, semi) => {
+            Stmt::Expr(expr, semi) => {
                 let modified_expr = add_locatorjs_id_to_expr(expr);
                 new_block.extend(quote! { #modified_expr #semi });
             }
@@ -74,16 +107,16 @@ fn add_locatorjs_id_to_block(block: Box<syn::Block>) -> Box<syn::Block> {
 }
 
 /// The add_locatorjs_id_to_expr function is used to modify an expression.
-/// It iterates over each token in the expression and checks if it matches the HTML_TAG_REGEX pattern.
+/// It iterates over each token in the expression and checks if it matches the HTML_REGEX pattern.
 /// If it does, the add_locatorjs_id_to_macro_tokens function is called to modify the token and add the data-locatorjs-id attribute.
-fn add_locatorjs_id_to_expr(expr: impl ToTokens) -> TokenStream2 {
-    let mut new_tokens = TokenStream2::new();
+fn add_locatorjs_id_to_expr(expr: impl ToTokens) -> TokenStream {
+    let mut new_tokens = TokenStream::new();
     let tokens = expr.into_token_stream();
 
     for token in tokens {
         let token_str = token.clone().to_string();
 
-        if HTML_TAG_REGEX.is_match(&token_str) {
+        if HTML_REGEX.is_match(&token_str) {
             let macro_tokens = token.clone().into_token_stream();
             let modified_tokens = add_locatorjs_id_to_macro_tokens(macro_tokens);
             new_tokens.extend(modified_tokens);
@@ -95,25 +128,56 @@ fn add_locatorjs_id_to_expr(expr: impl ToTokens) -> TokenStream2 {
     new_tokens
 }
 
-/// The add_locatorjs_id_to_macro_tokens function is used to modify a token that matches the HTML_TAG_REGEX pattern.
-/// It replaces the closing angle bracket > with the data-locatorjs-id attribute and the closing angle bracket.
-fn add_locatorjs_id_to_macro_tokens(tokens: TokenStream2) -> TokenStream2 {
-    let mut new_tokens = TokenStream2::new();
+/// Modifies HTML tags in a `TokenStream` by adding a `data-locatorjs-id` attribute.
+///
+/// This function iterates over the tokens in the input `TokenStream`, and for any token that matches the `HTML_TAG_REGEX` pattern,
+/// it adds the `data-locatorjs-id` attribute next to the tag.
+fn add_locatorjs_id_to_macro_tokens(tokens: TokenStream) -> TokenStream {
+    let mut new_tokens = TokenStream::new();
 
-    for token in tokens {
-        let tokens_block = token.clone().into_token_stream();
-        let tokens_a = tokens_block.to_string();
-        let locatorjs = HTML_TAG_REGEX.replace_all(&tokens_a, |captures: &Captures| {
-            let tag_elm = &captures[0];
-            let locatorjs = format!(
-                " attr:data-locatorjs-id=\"{}::{}\">",
-                "source_file", "file_line"
-            );
-            return tag_elm.replace(">", &locatorjs);
-        });
+    // Keep track of the last two characters encountered in the TokenStream.
+    // This is used to determine if a token is the start of an HTML tag.
+    let mut match_token: Vec<String> = vec![];
 
-        if let Ok(token_locatorjs) = TokenStream2::from_str(&locatorjs) {
-            new_tokens.extend(quote! { #token_locatorjs });
+    for token in tokens.clone() {
+        match token {
+            TokenTree::Group(group) => {
+                let new_group = Group::new(
+                    group.delimiter(),
+                    add_locatorjs_id_to_macro_tokens(group.stream()),
+                );
+                new_tokens.extend(TokenTree::Group(new_group).into_token_stream());
+            }
+            TokenTree::Ident(ident) => {
+                let tag = ident.clone().to_string();
+                if HTML_TAG_REGEX.is_match(&tag) {
+                    if let Some(tag_start) = match_token.last() {
+                        // If the last character was a "<", this is the start of an HTML tag.
+                        // Clear the match_token vector and add the data-locatorjs-id attribute to the tag.
+                        if tag_start.eq("<") {
+                            match_token.clear();
+                            let attr_locatorjs = format!("{}::{}", "path_to_file", "line_number");
+                            new_tokens
+                                .extend(quote! { #ident attr:data-locatorjs-id=#attr_locatorjs });
+                        } else {
+                            // The character was a "/" or others.
+                            new_tokens.extend(quote! { #ident });
+                        }
+                    }
+                } else {
+                    new_tokens.extend(quote! { #ident });
+                }
+            }
+            TokenTree::Punct(punct) => {
+                let char = punct.clone().to_string();
+                // If the token is a punctuation "<" or "/" character.
+                // If it is, add it to the match_token vector.
+                if char.eq("<") | char.eq("/") {
+                    match_token.push(char);
+                }
+                new_tokens.extend(quote! { #punct });
+            }
+            TokenTree::Literal(literal) => new_tokens.extend(quote! { #literal }),
         }
     }
 

--- a/lib.rs
+++ b/lib.rs
@@ -2,11 +2,25 @@ extern crate proc_macro;
 extern crate quote;
 extern crate syn;
 
-use proc_macro::TokenStream;
-use proc_macro2::{Group, TokenTree};
-use quote::{quote, ToTokens};
-use syn::{parse_macro_input, Expr, ExprMacro, ItemFn};
+use std::str::FromStr;
 
+use lazy_static::lazy_static;
+use regex::{Captures, Regex};
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, ItemFn, Stmt::*};
+
+lazy_static! {
+    // Match only few elements
+    static ref HTML_TAG_REGEX: Regex = Regex::new(r"<(div|h[1-6])\b[^>]*>").unwrap();
+}
+
+/// This macro adds the data-locatorjs-id attribute to all div, h1, h2, etc. elements in the source code.
+/// The attribute is used by the LocatorJS library to uniquely identify HTML elements in automated tests.
+/// The add_locatorjs_id function takes two arguments: _attr and item.
+/// The _attr argument is ignored, and the item argument is expected to be a function item.
 #[proc_macro_attribute]
 pub fn add_locatorjs_id(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
@@ -29,72 +43,77 @@ pub fn add_locatorjs_id(_attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
+/// The add_locatorjs_id_to_block function is used to modify the block of the function.
+/// It iterates over each statement in the block and checks if it matches one of the specified patterns.
+/// If it does, the add_locatorjs_id_to_expr function is called to modify the expression and add the data-locatorjs-id attribute.
 fn add_locatorjs_id_to_block(block: Box<syn::Block>) -> Box<syn::Block> {
-    let mut new_block = proc_macro2::TokenStream::new();
+    let mut new_block = TokenStream2::new();
 
     for stmt in block.stmts {
-        match stmt {
-            syn::Stmt::Expr(expr, semi) => {
+        match stmt.clone() {
+            Macro(stmt) => {
+                let modified_expr = add_locatorjs_id_to_expr(stmt);
+                new_block.extend(quote! { #modified_expr });
+            }
+            Local(local) => {
+                let modified_expr = add_locatorjs_id_to_expr(local);
+                new_block.extend(quote! { #modified_expr });
+            }
+            Item(item) => {
+                let modified_expr = add_locatorjs_id_to_expr(item);
+                new_block.extend(quote! { #modified_expr });
+            }
+            Expr(expr, semi) => {
                 let modified_expr = add_locatorjs_id_to_expr(expr);
                 new_block.extend(quote! { #modified_expr #semi });
             }
-            _ => new_block.extend(stmt.into_token_stream()),
         }
     }
 
     Box::new(syn::parse_quote!({ #new_block }))
 }
 
-fn add_locatorjs_id_to_expr(expr: Expr) -> proc_macro2::TokenStream {
-    match expr {
-        Expr::Macro(ExprMacro {
-            ref attrs, ref mac, ..
-        }) => {
-            let macro_path = mac.path.to_token_stream().to_string();
-            if macro_path == "view" {
-                let macro_tokens = mac.tokens.clone();
-                let modified_tokens = add_locatorjs_id_to_macro_tokens(macro_tokens);
-
-                quote! {
-                    #(#attrs)*
-                    view! { #modified_tokens }
-                }
-            } else {
-                expr.into_token_stream()
-            }
-        }
-        _ => expr.into_token_stream(),
-    }
-}
-
-fn add_locatorjs_id_to_macro_tokens(tokens: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let mut new_tokens = proc_macro2::TokenStream::new();
+/// The add_locatorjs_id_to_expr function is used to modify an expression.
+/// It iterates over each token in the expression and checks if it matches the HTML_TAG_REGEX pattern.
+/// If it does, the add_locatorjs_id_to_macro_tokens function is called to modify the token and add the data-locatorjs-id attribute.
+fn add_locatorjs_id_to_expr(expr: impl ToTokens) -> TokenStream2 {
+    let mut new_tokens = TokenStream2::new();
+    let tokens = expr.into_token_stream();
 
     for token in tokens {
-        match token {
-            TokenTree::Group(group) => {
-                let new_group = Group::new(
-                    group.delimiter(),
-                    add_locatorjs_id_to_macro_tokens(group.stream()),
-                );
-                new_tokens.extend(TokenTree::Group(new_group).into_token_stream());
-            }
-            TokenTree::Ident(ref ident) => {
-                let ident_str = ident.to_string();
-                if ident_str == "div"
-                    || ident_str == "h1"
-                    || ident_str.starts_with('h')
-                        && ident_str.len() == 2
-                        && ident_str.chars().nth(1).unwrap().is_numeric()
-                {
-                    new_tokens.extend(quote! {
-                        #ident data-locatorjs-id={concat!(file!(), "::", line!())}
-                    });
-                } else {
-                    new_tokens.extend(token.into_token_stream());
-                }
-            }
-            _ => new_tokens.extend(token.into_token_stream()),
+        let token_str = token.clone().to_string();
+
+        if HTML_TAG_REGEX.is_match(&token_str) {
+            let macro_tokens = token.clone().into_token_stream();
+            let modified_tokens = add_locatorjs_id_to_macro_tokens(macro_tokens);
+            new_tokens.extend(modified_tokens);
+        } else {
+            new_tokens.extend(token.into_token_stream());
+        }
+    }
+
+    new_tokens
+}
+
+/// The add_locatorjs_id_to_macro_tokens function is used to modify a token that matches the HTML_TAG_REGEX pattern.
+/// It replaces the closing angle bracket > with the data-locatorjs-id attribute and the closing angle bracket.
+fn add_locatorjs_id_to_macro_tokens(tokens: TokenStream2) -> TokenStream2 {
+    let mut new_tokens = TokenStream2::new();
+
+    for token in tokens {
+        let tokens_block = token.clone().into_token_stream();
+        let tokens_a = tokens_block.to_string();
+        let locatorjs = HTML_TAG_REGEX.replace_all(&tokens_a, |captures: &Captures| {
+            let tag_elm = &captures[0];
+            let locatorjs = format!(
+                " attr:data-locatorjs-id=\"{}::{}\">",
+                "source_file", "file_line"
+            );
+            return tag_elm.replace(">", &locatorjs);
+        });
+
+        if let Ok(token_locatorjs) = TokenStream2::from_str(&locatorjs) {
+            new_tokens.extend(quote! { #token_locatorjs });
         }
     }
 


### PR DESCRIPTION
Iterate over each token to modify the html tags.
```rust
// line 142
for token in tokens.clone() {
   match token {
      ...
   }
}
```

If it's a `<` or `/` character, store it in an array and use it to determine whether the tag is opening or closing.
```rust
// line 175
if char.eq("<") | char.eq("/") {
   match_token.push(char);
}
```

If it's opening, it adds the attribute/value to the tag.
```rust
// line 157
if tag_start.eq("<") {
   match_token.clear();
   let attr_locatorjs = format!("{}::{}", "path_to_file", "line_number");
   new_tokens.extend(quote! { #ident attr:data-locatorjs-id=#attr_locatorjs });
} else {
   // The character was a "/" or others.
   new_tokens.extend(quote! { #ident });
}
```